### PR TITLE
Custom registries

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@ namespace: darthlukan
 
 name: argocd_install
 
-version: 1.1.3
+version: 1.2.0
 
 readme: README.md
 

--- a/roles/install_argocd/defaults/main.yml
+++ b/roles/install_argocd/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 # scope is namespace or cluster
+# When setting scope to 'cluster', the role applies an elevated ClusterRoleBinding to 
+# argocd-operator service account, cluster-admin to the argocd-application-controller 
+# service account, and sets the 'WATCH_NAMESPACE' of the operator Deployment to "" (all namespaces)
 scope: namespace
 
 # state is present or absent

--- a/roles/install_argocd/defaults/main.yml
+++ b/roles/install_argocd/defaults/main.yml
@@ -12,4 +12,8 @@ kubeconfig: "{{ lookup('env', 'HOME') }}/.minishift/machines/minishift_kubeconfi
 # The namespace to install the operator into.
 # Used for both namespace and cluster scoped installations.
 namespace: argocd
+
+# The internal registry used by the cluster to proxy or mirror or pull-through images.
+# Used for both namespace or cluster scoped installations.
+internal_registry: ""
 ...

--- a/roles/install_argocd/defaults/main.yml
+++ b/roles/install_argocd/defaults/main.yml
@@ -7,7 +7,7 @@ state: present
 
 # Replace with the path to your kubeconfig
 # NOTE: Must be cluster-admin to install CRDs and cluster scoped operator!
-kubeconfig: "/home/{{ ansible_user_id }}/.minishift/machines/minishift_kubeconfig"
+kubeconfig: "{{ lookup('env', 'HOME') }}/.minishift/machines/minishift_kubeconfig"
 
 # The namespace to install the operator into.
 # Used for both namespace and cluster scoped installations.

--- a/roles/install_argocd/tasks/configure.yaml
+++ b/roles/install_argocd/tasks/configure.yaml
@@ -2,12 +2,17 @@
 - name: Get default ArgoCD operator.yaml
   set_fact:
     operator_json: "{{ lookup('file', \"{{ role_path }}/files/argocd-operator/deploy/operator.yaml\") | from_yaml }}"
-  when: scope == 'cluster'
+  when: scope == 'cluster' or internal_registry != ""
 
 - name: Set operator_image
   set_fact:
     operator_image: "{{ operator_json.spec.template.spec.containers[0].image }}"
-  when: scope == 'cluster'
+  when: scope == 'cluster' and internal_registry == ""
+
+- name: Set internal_registry + operator_image
+  set_fact:
+    operator_image: "{{ internal_registry }}/{{ operator_json.spec.template.spec.containers[0].image }}"
+  when: internal_registry != ""
 
 - name: Populate cluster-operator.yaml
   template:
@@ -15,5 +20,5 @@
     dest: "{{ role_path }}/files/argocd-operator/deploy/operator.yaml"
     # Need to force since we're replacing the default
     force: yes
-  when: scope == 'cluster'
+  when: scope == 'cluster' or internal_registry != ""
 ...

--- a/roles/install_argocd/tasks/install.yaml
+++ b/roles/install_argocd/tasks/install.yaml
@@ -75,6 +75,4 @@
     - operator.yaml
   # if state == absent the namespace will be removed in the setup.yaml and this would error.
   when: state == 'present'
-
-
 ...

--- a/roles/install_prereqs/defaults/main.yml
+++ b/roles/install_prereqs/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-bin_dir: "/home/{{ ansible_user_id }}/bin"
+bin_dir: "{{ lookup('env', 'HOME') }}/bin"
 ocp_major_version: 4
 ...


### PR DESCRIPTION
Allow custom registry to be specified via the `internal_registry` var. Works for both cluster and namespace scoped installations. Tested with CRC/OCP 4.5.x.

Also uses `$HOME` for default `~/bin` specification.

Fixes #3  
Fixes #2 

